### PR TITLE
ci(smoke): add timeout for contract test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,4 +29,4 @@ jobs:
         run: docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace tron-dev:ci cargo test --quiet
 
       - name: Run contract test
-        run: bash ./specs/002-replace-the-current/contracts/tests/test_hello_run.sh
+        run: timeout 10m bash -lc 'set -x; IMAGE=tron-dev:ci bash ./specs/002-replace-the-current/contracts/tests/test_hello_run.sh'


### PR DESCRIPTION
Add a 10m timeout wrapper around the contract test invocation to ensure the workflow step can't stall indefinitely. This also sets IMAGE=tron-dev:ci in the script so it reuses the already-built image tag.